### PR TITLE
Let users provide their own unbound.conf

### DIFF
--- a/1.7.0/unbound.sh
+++ b/1.7.0/unbound.sh
@@ -16,11 +16,13 @@ else
     threads=1
 fi
 
-sed \
-    -e "s/@MSG_CACHE_SIZE@/${msg_cache_size}/" \
-    -e "s/@RR_CACHE_SIZE@/${rr_cache_size}/" \
-    -e "s/@THREADS@/${threads}/" \
-    > /opt/unbound/etc/unbound/unbound.conf << EOT
+# Allow the user to provide its own unbound.conf file via mounting
+if [ ! -f /opt/unbound/etc/unbound/unbound.conf ]; then
+    sed \
+        -e "s/@MSG_CACHE_SIZE@/${msg_cache_size}/" \
+        -e "s/@RR_CACHE_SIZE@/${rr_cache_size}/" \
+        -e "s/@THREADS@/${threads}/" \
+        > /opt/unbound/etc/unbound/unbound.conf << EOT
 server:
   verbosity: 1
   num-threads: @THREADS@
@@ -84,6 +86,8 @@ remote-control:
   control-enable: no
 
 EOT
+fi
+
 
 mkdir -p /opt/unbound/etc/unbound/dev && \
 cp -a /dev/random /dev/urandom /opt/unbound/etc/unbound/dev/


### PR DESCRIPTION
It might be useful to run unbound with a custom configuration and the current cmd script doesn't allow it. 

By checking if the unbound configuration is present, we can let users start the docker container mounting their own unbound configuration.

```
docker run $(pwd)/unbound.conf:/opt/unbound/etc/unbound/unbound.conf:ro -p 53:53/udp mvance/unbound:latest
```

@MatthewVance if you find this useful I can add it to the remaining unbound versions