### PR TITLE
Expose both TCP and UDP

### DIFF
--- a/1.9.4/Dockerfile
+++ b/1.9.4/Dockerfile
@@ -125,7 +125,8 @@ WORKDIR /opt/unbound/
 
 ENV PATH /opt/unbound/sbin:"$PATH"
 
-EXPOSE 53
+EXPOSE 53/tcp
+EXPOSE 53/udp
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD drill @127.0.0.1 cloudflare.com || exit 1
 


### PR DESCRIPTION
Default is just TCP which causes problems in tooling like testcontainers that tries to map the exposed ports automatically.