### PR TITLE
Include /dev/null for logging

### DIFF
--- a/1.9.6/unbound.sh
+++ b/1.9.6/unbound.sh
@@ -363,7 +363,7 @@ EOT
 fi
 
 mkdir -p /opt/unbound/etc/unbound/dev && \
-cp -a /dev/random /dev/urandom /opt/unbound/etc/unbound/dev/
+cp -a /dev/random /dev/urandom /dev/null /opt/unbound/etc/unbound/dev/
 
 mkdir -p -m 700 /opt/unbound/etc/unbound/var && \
 chown _unbound:_unbound /opt/unbound/etc/unbound/var && \


### PR DESCRIPTION
In unbound.conf the logfile is set to /dev/null.
When unbound can't log to the specified file it defaults to syslog, which defeats the purpose of logging to /dev/null. 