### PR TITLE
Unbound 1.13.1 & OpenSSL 1.1.1k

### DIFF
--- a/1.13.1/Dockerfile
+++ b/1.13.1/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:buster as openssl
 LABEL maintainer="Matthew Vance"
 
-ENV VERSION_OPENSSL=openssl-1.1.1i \
-    SHA256_OPENSSL=e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242 \
+ENV VERSION_OPENSSL=openssl-1.1.1k \
+    SHA256_OPENSSL=892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5 \
     SOURCE_OPENSSL=https://www.openssl.org/source/ \
     OPGP_OPENSSL=8657ABB260F056B1E5190839D9C4D26D0E604491
 


### PR DESCRIPTION
No changes to Unbound.  Just an update to OpenSSL, bringing it to version 1.1.1k to include fix for CVE-2021-3450.