### PR TITLE
README: Add k3s section

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,33 @@ Overall, this approach is very similar to the `a-records.conf` approach describe
 ***Note:** Care has been taken in the image's default configuration to enable
 security options so it is recommended to use it as a guide.*
 
+### k3s usage
+
+> The method described here is basic and I would not recommend it for larger environments atm.
+
+In order to spin the deployment up use:
+
+```
+kubectl apply -f unbound-main-conf.yml -f other-files.yml ...
+```
+
+Remember when taking it down to use the reverse order in which you spun the deployment up.
+
+Restarting:
+
+```
+kubectl rollout restart deployment dns 
+```
+
+An example deployment can be viewed [here](k8s/deployment.yml). It is not ready since you need to fill it with your
+records and the main unbound configuration file.
+
+> A fair warning: I am using not using a Service but hostPort, thus this is only a start. In theory one should not do 
+> that in a production cluster.
+
+> Additional warning: As per [this](https://kubernetes.io/docs/concepts/configuration/secret/) document the default
+> secrets configuration is unencrypted per default. You are responsible to harden this yourself and should do so!
+
 # User feedback
 
 ## Documentation

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -1,0 +1,128 @@
+# This file is an example! Do not use before editing it!
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbound-main-conf
+data:
+  unbound.conf: |
+    <INSERT CONF>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbound-a-records-conf
+data:
+  a-records.conf: | 
+    server:
+        # Your internal network name and addresses go here
+        private-domain: "your-awesome-domain.local"
+        domain-insecure: "your-awesome-domain.local"
+        local-zone: "your-awesome-domain.local" transparent
+
+        local-data: "k8s.your-awesome-domain.local IN A 172.30.0.1"
+        #local-data-ptr: "172.30.0.1 your-awesome-domain.local"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbound-forward-records-conf
+data:
+  forward-records.conf: |  
+    forward-zone:
+        # Forward all queries (except those in cache and local zone) to
+        # upstream recursive servers
+        name: "."
+        # Queries to this forward zone use TLS
+        forward-tls-upstream: yes
+
+        # https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Test+Servers
+
+        # Cloudflare
+        forward-addr: 1.1.1.1@853#cloudflare-dns.com
+        forward-addr: 1.0.0.1@853#cloudflare-dns.com
+        #forward-addr: 2606:4700:4700::1111@853#cloudflare-dns.com
+        #forward-addr: 2606:4700:4700::1001@853#cloudflare-dns.com
+
+        # CleanBrowsing
+        forward-addr: 185.228.168.9@853#security-filter-dns.cleanbrowsing.org
+        forward-addr: 185.228.169.9@853#security-filter-dns.cleanbrowsing.org
+        # forward-addr: 2a0d:2a00:1::2@853#security-filter-dns.cleanbrowsing.org
+        # forward-addr: 2a0d:2a00:2::2@853#security-filter-dns.cleanbrowsing.org
+
+        # Quad9
+        # forward-addr: 9.9.9.9@853#dns.quad9.net
+        # forward-addr: 149.112.112.112@853#dns.quad9.net
+        # forward-addr: 2620:fe::fe@853#dns.quad9.net
+        # forward-addr: 2620:fe::9@853#dns.quad9.net
+
+        # getdnsapi.net
+        # forward-addr: 185.49.141.37@853#getdnsapi.net
+        # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
+
+        # Surfnet
+        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
+        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
+        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
+        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbound-srv-records-conf
+data:
+  srv-records.conf: |  
+    # SRV records
+    # _service._proto.name. | TTL | class | SRV | priority | weight | port | target.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: unbound-dns
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: unbound-dns
+    spec:
+      containers:
+        - image: mvance/unbound
+          imagePullPolicy: IfNotPresent
+          name: dns-unbound
+          ports:
+            - containerPort: 53
+              hostPort: 53
+              protocol: UDP
+          resources: {}
+          volumeMounts:
+            - name: unbound-main-conf-volume
+              mountPath: /opt/unbound/etc/unbound/unbound.conf
+              subPath: unbound.conf
+            - name: unbound-a-conf-volume
+              mountPath: /opt/unbound/etc/unbound/a-records.conf
+              subPath: a-records.conf
+            - name: unbound-forward-conf-volume
+              mountPath: /opt/unbound/etc/unbound/forward-records.conf
+              subPath: forward-records.conf
+            - name: unbound-srv-conf-volume
+              mountPath: /opt/unbound/etc/unbound/srv-records.conf
+              subPath: srv-records.conf
+      restartPolicy: Always
+      volumes:
+        - name: unbound-main-conf-volume
+          configMap:
+            name: unbound-main-conf
+        - name: unbound-a-conf-volume
+          configMap:
+            name: unbound-a-records-conf
+        - name: unbound-forward-conf-volume
+          configMap:
+            name: unbound-forward-records-conf
+        - name: unbound-srv-conf-volume
+          configMap:
+            name: unbound-srv-records-conf


### PR DESCRIPTION
This fixes #84 

This is a first draft for adding k3s deployment instructions. In the long run I would propose a separate repo which should evolve into a helmchart. The different environments we have in k8s environments require a lot of documentation not required for Docker.

Since this is a first draft, I am open for changes in any way desired.