### PR TITLE
Enable ECS module

### DIFF
--- a/1.15.0/Dockerfile
+++ b/1.15.0/Dockerfile
@@ -81,7 +81,8 @@ RUN build_deps="curl gcc libc-dev libevent-dev libexpat1-dev libnghttp2-dev make
         --enable-dnstap \
         --enable-tfo-server \
         --enable-tfo-client \
-        --enable-event-api && \
+        --enable-event-api \
+        --enable-subnet && \
     make install && \
     mv /opt/unbound/etc/unbound/unbound.conf /opt/unbound/etc/unbound/unbound.conf.example && \
     apt-get purge -y --auto-remove \


### PR DESCRIPTION
This small patch enables the module necessary for EDNS Client Subnet / ECS (per unbound docs). Would be great if it could be accepted!

I've applied the patch only to the Dockerfile of the latest version, I hope it's the appropriate place.