### PR TITLE
Fix 1.16.2/Dockerfile parsing error

### DIFF
--- a/1.16.2/Dockerfile
+++ b/1.16.2/Dockerfile
@@ -44,7 +44,7 @@ FROM debian:bullseye as unbound
 LABEL maintainer="Matthew Vance"
 
 ENV NAME=unbound \
-    UNBOUND_VERSION=1.16.2
+    UNBOUND_VERSION=1.16.2 \
     UNBOUND_SHA256=2e32f283820c24c51ca1dd8afecfdb747c7385a137abe865c99db4b257403581 \
     UNBOUND_DOWNLOAD_URL=https://nlnetlabs.nl/downloads/unbound/unbound-1.16.2.tar.gz
 


### PR DESCRIPTION
Missing a `\` in on a line causing the building of the container to fail.

```
dockerfile parse error line 48: unknown instruction: UNBOUND_SHA256=2E32F28382    0C24C51CA1DD8AFECFDB747C7385A137ABE865C99DB4B257403581
```