### PR TITLE
Remove decommissioned dnsovertls*.sinodun.com resolvers

### DIFF
--- a/1.10.0/forward-records.conf
+++ b/1.10.0/forward-records.conf
@@ -28,9 +28,3 @@ forward-zone:
     # getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    # Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.10.1/forward-records.conf
+++ b/1.10.1/forward-records.conf
@@ -28,9 +28,3 @@ forward-zone:
     # getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    # Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.11.0/forward-records.conf
+++ b/1.11.0/forward-records.conf
@@ -28,9 +28,3 @@ forward-zone:
     # getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    # Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.12.0/forward-records.conf
+++ b/1.12.0/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.13.0/forward-records.conf
+++ b/1.13.0/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.13.1/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.13.1/data/opt/unbound/etc/unbound/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.13.2/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.13.2/data/opt/unbound/etc/unbound/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.14.0/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.14.0/data/opt/unbound/etc/unbound/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.15.0/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.15.0/data/opt/unbound/etc/unbound/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.16.0/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.16.0/data/opt/unbound/etc/unbound/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.16.1/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.16.1/data/opt/unbound/etc/unbound/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.16.2/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.16.2/data/opt/unbound/etc/unbound/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.16.3/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.16.3/data/opt/unbound/etc/unbound/forward-records.conf
@@ -40,9 +40,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.17.0/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.17.0/data/opt/unbound/etc/unbound/forward-records.conf
@@ -52,9 +52,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.17.1/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.17.1/data/opt/unbound/etc/unbound/forward-records.conf
@@ -52,9 +52,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.18.0/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.18.0/data/opt/unbound/etc/unbound/forward-records.conf
@@ -52,9 +52,3 @@ forward-zone:
     ## getdnsapi.net
     # forward-addr: 185.49.141.37@853#getdnsapi.net
     # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-    ## Surfnet
-    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.8.2/unbound.sh
+++ b/1.8.2/unbound.sh
@@ -351,12 +351,6 @@ server:
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
 
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
-
 remote-control:
     control-enable: no
 EOT

--- a/1.8.3/unbound.sh
+++ b/1.8.3/unbound.sh
@@ -351,12 +351,6 @@ server:
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
 
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
-
 remote-control:
     control-enable: no
 EOT

--- a/1.9.0/unbound.sh
+++ b/1.9.0/unbound.sh
@@ -351,12 +351,6 @@ server:
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
 
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
-
 remote-control:
     control-enable: no
 EOT

--- a/1.9.1/unbound.sh
+++ b/1.9.1/unbound.sh
@@ -351,12 +351,6 @@ server:
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
 
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
-
 remote-control:
     control-enable: no
 EOT

--- a/1.9.2/unbound.sh
+++ b/1.9.2/unbound.sh
@@ -351,12 +351,6 @@ server:
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
 
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
-
 remote-control:
     control-enable: no
 EOT

--- a/1.9.3/unbound.sh
+++ b/1.9.3/unbound.sh
@@ -351,12 +351,6 @@ server:
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
 
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
-
 remote-control:
     control-enable: no
 EOT

--- a/1.9.4/unbound.sh
+++ b/1.9.4/unbound.sh
@@ -351,12 +351,6 @@ server:
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
 
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
-
 remote-control:
     control-enable: no
 EOT

--- a/1.9.5/unbound.sh
+++ b/1.9.5/unbound.sh
@@ -351,12 +351,6 @@ server:
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
 
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
-
 remote-control:
     control-enable: no
 EOT

--- a/1.9.6/unbound.sh
+++ b/1.9.6/unbound.sh
@@ -351,12 +351,6 @@ server:
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
 
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
-
 remote-control:
     control-enable: no
 EOT

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -58,12 +58,6 @@ data:
         # getdnsapi.net
         # forward-addr: 185.49.141.37@853#getdnsapi.net
         # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
-
-        # Surfnet
-        # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
-        # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
-        # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
The dnsovertls*.sinodun.com were decommissioned last year. See also https://dnsprivacy.org/test_servers/