### PR TITLE
Enable redis backend in 1.20.0

### DIFF
--- a/1.20.0/Dockerfile
+++ b/1.20.0/Dockerfile
@@ -69,6 +69,7 @@ RUN build_deps="curl gcc libc-dev libevent-dev libexpat1-dev libnghttp2-dev make
       ca-certificates \
       ldnsutils \
       libevent-2.1-7 \
+      libhiredis-dev \
       libexpat1 \
       libprotobuf-c-dev \
       protobuf-c-compiler && \
@@ -86,6 +87,7 @@ RUN build_deps="curl gcc libc-dev libevent-dev libexpat1-dev libnghttp2-dev make
         --with-username=_unbound \
         --with-ssl=/opt/openssl \
         --with-libevent \
+        --with-libhiredis \
         --with-libnghttp2 \
         --enable-dnstap \
         --enable-tfo-server \
@@ -120,6 +122,7 @@ RUN set -x && \
       ca-certificates \
       ldnsutils \
       libevent-2.1-7 \
+      libhiredis0.14 \
       libnghttp2-14 \
       libexpat1 \
       libprotobuf-c1 && \

--- a/1.20.0/data/unbound.sh
+++ b/1.20.0/data/unbound.sh
@@ -42,6 +42,14 @@ server:
     ###########################################################################
     # BASIC SETTINGS
     ###########################################################################
+    # Modules used by unbound. Default is "validator iterator"
+    # Uncomment to enable Redis support (configured at the bottom  of the file)
+    # modules:
+    #  validator - validates the security fingerprints on data sets
+    #  cachedb - persistent store for data from previous queries
+    #  iterator - sends queries to the hierarchical DNS servers that own the data
+    # module-config: "validator cachedb iterator"
+    
     # Time to live maximum for RRsets and messages in the cache. If the maximum
     # kicks in, responses to clients still get decrementing TTLs based on the
     # original (larger) values. When the internal TTL expires, the cache item
@@ -388,6 +396,31 @@ server:
 
 remote-control:
     control-enable: no
+
+###########################################################################
+# REDIS
+###########################################################################
+# Requires enabling 'cachedb' module in the server's 'module-config' section.
+# When enabled, Redis works  as  a second level cache.
+# This module interacts with the serve-expired-* options and  will  reply
+# with expired data if Unbound is configured for that.
+#
+# Unbound never removes data stored in the Redis  server, so cache-size and
+# eviction policy should be set on the Redis side.
+#
+# cachedb:
+    ###########################################################################
+    # CONNECTION SETTINGS
+    ###########################################################################
+    # Replace the default "testframe" db with Redis
+    # backend: "redis"
+
+    # ip address or domain  name  of  the  Redis server.
+    # defaults to 127.0.0.1
+    # redis-server-host: 127.0.0.1
+
+    # The TCP port number of the Redis server. Defaultsto 6379.
+    # redis-server-port: 6379
 EOT
 fi
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,31 @@ By default, this image includes a healthcheck that performs a query for *cloudfl
 
 To disable the healthcheck, add the `--no-healthcheck` flag to your Dockerfile. If using docker-compose, you can configure the healthcheck differently as explained in the [Docker docs](https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck).
 
+
+### Redis Persistent storage
+By default, Unbound runs without any kind of persistence: cache is dropped when restarting the container.
+Optionally, since 1.20.0 it is possible to enable Redis as the storage backend.
+
+Note, that Unbound never removes data stored in the Redis server, 
+so cache-size and eviction policy should be set on the Redis side.
+
+Enabling Redis as a backend requires two changes to the `unbound.conf`:
+
+#### 1. Enable cachedb module:
+In the `seerver` section add the following line:
+```
+module-config: "validator cachedb iterator"
+```
+
+#### 2. Configure Redis Connection
+Add the following section, filling in the redis address. Note, that this should not be nested in the `server` section, but rather on its own:
+```
+cachedb:
+    backend: "redis"
+    redis-server-host: 127.0.0.1
+    redis-server-port: 6379
+```
+
 ## Known issues
 
 The following message may appears in the logs about IPv6 Address Assignment:


### PR DESCRIPTION
Currently, there is no way to attach the Unbound Container to a Redis Database.
This change compiles the 
The resulting image is marginally bigger: < 1%
![image](https://github.com/user-attachments/assets/d8bcd857-9acc-4ed8-be57-64f7e92ef645)

## Verification

### Checkout code
```bash
cd /tmp
git clone https://github.com/mzarnowski/unbound-docker.git --branch=enable-redis-backend
cd unbound-docker/1.20.0/
```

### Configure unbound
The unbound.conf includes two changes:
#### Enabled cachedb module:
```
module-config: "validator cachedb iterator"
```

#### Configured Redis connection
```
cachedb:
    backend: "redis"
    redis-server-host: 10.91.0.20
```

### Start Containers
```bash
podman network create foo-net --subnet=10.91.0.0/24

podman run --detach --net=foo-net --name=foo-redis --ip=10.91.0.20 "docker.io/library/redis:7.4.1-alpine3.20" --save 60 1000 --loglevel warning --maxmemory 4mb --maxmemory-policy allkeys-lfu

podman run --detach --net=foo-net --name=foo-unbound -v /tmp/unbound-docker/1.20.0/unbound.conf:/opt/unbound/etc/unbound/unbound.conf:ro,z -p "5353:53/udp" -p "5353:53/tcp" -it localhost/unbound-redis
```

### Observe that Unbound connects to Redis
```bash
podman logs foo-unbound
```
![image](https://github.com/user-attachments/assets/46aa488c-5838-48ab-96e8-e1207f90716a)

### Observe that received DNS request is stored in Redis
```bash
dig +short wykop.pl @localhost -p 5353
```
![image](https://github.com/user-attachments/assets/0f256c3a-812f-4938-9849-ddf7dc5467b0)

```bash
podman exec -it foo-redis redis-cli keys '*'
```
![image](https://github.com/user-attachments/assets/9f829af5-869d-48a2-bddf-61e02a88ea7c)

### Ovserve that after restart, Unbound consults Redis
```bash
podman restart foo-unbound
dig +short wykop.pl @localhost -p 5353
podman logs foo-unbound
```
![image](https://github.com/user-attachments/assets/7c028e14-a135-4e1b-bc6b-0fb481e243e8)

